### PR TITLE
可以设置是否用严格模式

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ es6 parser for fis
 ### INSTALL
 
 ```bash
-npm install -g xiangshouding/fis-parser-babel
+npm install -g cuidingfeng/fis-parser-babel
 ```
 
 ### USE
@@ -16,7 +16,8 @@ npm install -g xiangshouding/fis-parser-babel
 	
 	```js
 	fis.match('/es6/**.js', {
-		parser: fis.plugin('babel')
+		parser: fis.plugin('babel'),
+		notStrict: true //是否不使用严格模式，默认为false，使用严格模式。
 	});
 	```
 	
@@ -31,6 +32,7 @@ npm install -g xiangshouding/fis-parser-babel
 	fis.config.set('roadmap.path', [
 		{
 			reg: '/es6/**.js',
+			notStrict: true, //是否不使用严格模式，默认为false，使用严格模式。
 			isES6: true
 		},
 		{

--- a/index.js
+++ b/index.js
@@ -9,5 +9,8 @@ module.exports = function (content, file, opts) {
   if (!file.isES6) return content;
   opts.moduleId = file.getId();
   var result = babel.transform(content, opts);
+  if(file.notStrict){
+    return result.code.replace(/(['"])use strict\1;/g,'');
+  }
   return result.code;
 };

--- a/package.json
+++ b/package.json
@@ -12,15 +12,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xiangshouding/fis-parser-babel.git"
+    "url": "git+https://github.com/cuidingfeng/fis-parser-babel.git"
   },
   "keywords": [
-    "fis"
+    "fis",
+    "es6"
   ],
   "author": "fansekey",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/xiangshouding/fis-parser-babel/issues"
+    "url": "https://github.com/cuidingfeng/fis-parser-babel/issues"
   },
-  "homepage": "https://github.com/xiangshouding/fis-parser-babel#readme"
+  "homepage": "https://github.com/cuidingfeng/fis-parser-babel#readme"
 }


### PR DESCRIPTION
默认是严格模式，设置文件的notStrict属性为true时，使用正常模式解析js。

fis-conf.js配置示例：
fis.match('*.es6', {
  rExt: '.js',
  parser: fis.plugin('babel2'),
  notStrict: true
});

在js中__inline模板时，fis生成的js中包含with语句，在严格模式会报错。
